### PR TITLE
Fix doy/index issues

### DIFF
--- a/pynar/modele_pheno_gdd.py
+++ b/pynar/modele_pheno_gdd.py
@@ -92,7 +92,7 @@ def selection_stage(UPVT,start_stage,end_stage,latitude,longitude):
 
     data_compute = xr.apply_ufunc(
         lambda x, start, end: np.where(
-        (np.arange(len(x)) <= start) | (np.arange(len(x)) >= end), 0, x
+        (np.arange(len(x)) < start) | (np.arange(len(x)) > end), 0, x
         ),
         UPVT,  # Xarray contenant les données de température
         start_stage.stage,  # Xarray contenant les indices de début (start)


### PR DESCRIPTION
### What kind of change does this PR introduce?

* Convert day of year (doy) to index in `selection_stage` before performing the selection
* Change index selection in `selection_stage` to include start and end of the period: the old behaviour selected `start` and `end` with "<=" and ">=" respectively, meaning that for a start doy of *n*, the accumulation started at *n+1*. This PR corrects that.
* Change operator from ">" to ">=" to determine when GDD is reached and convert back to doy its index